### PR TITLE
[BUG-49] Feature/input styles issue

### DIFF
--- a/src/styles/spectre-fixes.sass
+++ b/src/styles/spectre-fixes.sass
@@ -2,3 +2,9 @@
 .form-horizontal .form-group
   -ms-flex-wrap: wrap
   flex-wrap: wrap
+
+// this might be solved by using postcss - spectre.css > forms only has rule for 'appearance' without any vendor prefix
+.form-input
+  -webkit-appearance: none
+  -moz-appearance: none
+  appearance: none


### PR DESCRIPTION
PR to story BUG-49 - Text input has a strange shadow on iPhone

Fixes issue with weird shadow on input fields on iOS safari and other -webkit- and -moz- browsers